### PR TITLE
:bug: cannot perform symmetric difference of same interval

### DIFF
--- a/src/main/java/net/emaze/dysfunctional/ranges/MakeRange.java
+++ b/src/main/java/net/emaze/dysfunctional/ranges/MakeRange.java
@@ -35,6 +35,9 @@ public class MakeRange<T> implements Function<List<DenseRange<T>>, Range<T>> {
         if (densified.size() == 1) {
             return densified.get(0);
         }
+        if (densified.isEmpty()) {
+            return empty;
+        }
         return new SparseRange<T>(sequencer, comparator, densified);
     }
 }

--- a/src/test/java/net/emaze/dysfunctional/RangesTest.java
+++ b/src/test/java/net/emaze/dysfunctional/RangesTest.java
@@ -319,6 +319,15 @@ public class RangesTest {
             Assert.assertEquals(Arrays.asList(0, 2), Consumers.all(got));
         }
 
+        @Test
+        public void symmetricDifferenceOfSameIntervalLeadToAnEmptyRange() {
+            final Ranges<Integer> ranges = new Ranges<Integer>(new ComparableComparator<Integer>(), new NextIntegerSequencingPolicy(), 0);
+            final Range<Integer> lhs = ranges.closed(0, 1);
+            final Range<Integer> rhs = ranges.closed(0, 1);
+            final Range<Integer> got = ranges.symmetricDifference(lhs, rhs);
+            Assert.assertEquals(ranges.empty(), got);
+        }
+
         @Test(expected = IllegalArgumentException.class)
         public void evaluatingSymmetricDifferenceOfAnEmptyIteratorYieldsException() {
             final Ranges<Integer> ranges = new Ranges<Integer>(new ComparableComparator<Integer>(), new NextIntegerSequencingPolicy(), 0);

--- a/src/test/java/net/emaze/dysfunctional/ranges/MakeRangeTest.java
+++ b/src/test/java/net/emaze/dysfunctional/ranges/MakeRangeTest.java
@@ -16,4 +16,13 @@ public class MakeRangeTest {
                 r(Endpoint.Include, 5, 10, Endpoint.Exclude)));
         Assert.assertEquals(r(Endpoint.Include, 0, 10, Endpoint.Exclude), got);
     }
+
+    @Test
+    public void desnifyEmptyRangesIntoEmptyRange() {
+        final MakeRange<Integer> maker = new MakeRange<>(sequencer, comparator, 0);
+        final Range<Integer> got = maker.apply(Arrays.asList(
+                r(Endpoint.Include, 0, 0, Endpoint.Exclude),
+                r(Endpoint.Include, 0, 0, Endpoint.Exclude)));
+        Assert.assertEquals(r(Endpoint.Include, 0, 0, Endpoint.Exclude), got);
+    }
 }


### PR DESCRIPTION
If perform symmetric difference of same interval due to an exception during union step.
Fix MakeRange to support this scenario, and add some tests